### PR TITLE
Change assertions to be more inline with java.util.concurrent.ThreadPoolExecutor

### DIFF
--- a/src/main/java/fr/xebia/springframework/concurrent/ThreadPoolExecutorFactory.java
+++ b/src/main/java/fr/xebia/springframework/concurrent/ThreadPoolExecutorFactory.java
@@ -182,9 +182,10 @@ public class ThreadPoolExecutorFactory extends AbstractFactoryBean<ThreadPoolExe
 
     @Override
     protected ThreadPoolExecutor createInstance() throws Exception {
-        Assert.isTrue(this.corePoolSize > 0, "corePoolSize must be greater than zero");
+        Assert.isTrue(this.corePoolSize >= 0, "corePoolSize must be greater than or equal to zero");
         Assert.isTrue(this.maximumPoolSize > 0, "maximumPoolSize must be greater than zero");
-        Assert.isTrue(this.queueCapacity > 0, "queueCapacity must be greater than zero");
+        Assert.isTrue(this.maximumPoolSize >= this.corePoolSize, "maximumPoolSize must be greater than or equal to corePoolSize");
+        Assert.isTrue(this.queueCapacity >= 0, "queueCapacity must be greater than or equal to zero");
 
         CustomizableThreadFactory threadFactory = new CustomizableThreadFactory(this.beanName + "-");
         threadFactory.setDaemon(true);


### PR DESCRIPTION
The current assertions do not allow you to set the queue capacity to zero to use the SynchronousQueue set by the below condition

``` java
if (queueCapacity == 0) {
    blockingQueue = new SynchronousQueue<Runnable>();
} else {
    blockingQueue = new LinkedBlockingQueue<Runnable>(queueCapacity);
}
```
